### PR TITLE
Remove deprecated "bottle :unneeded"

### DIFF
--- a/Formula/cw.rb
+++ b/Formula/cw.rb
@@ -6,7 +6,6 @@ class Cw < Formula
   desc "The best way to tail AWS Cloudwatch Logs from your terminal"
   homepage "https://www.lucagrulla.com/cw"
   version "4.1.0"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/lucagrulla/cw/releases/download/v4.1.0/cw_4.1.0_Darwin_x86_64.tar.gz"

--- a/Formula/heracles.rb
+++ b/Formula/heracles.rb
@@ -6,7 +6,6 @@ class Heracles < Formula
   desc "Your favourite Fitbit-> Withings scale data importer"
   homepage "https://github.com/lucagrulla/heracles"
   version "0.1.2"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/lucagrulla/heracles/releases/download/v0.1.2/heracles_0.1.2_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
Removed in [`brew` 3.2.1](https://github.com/Homebrew/brew/releases/tag/3.2.1).

Closes https://github.com/lucagrulla/homebrew-tap/issues/2.